### PR TITLE
[BUGFIX] Declare nullable parameter explicitly for PHP 8.4 compatibility

### DIFF
--- a/Classes/TcaHelper.php
+++ b/Classes/TcaHelper.php
@@ -18,7 +18,7 @@ namespace B13\Tag;
  */
 class TcaHelper
 {
-    public function buildFieldConfiguration(string $table, string $fieldName, array $fieldConfigurationOverride = null): array
+    public function buildFieldConfiguration(string $table, string $fieldName, ?array $fieldConfigurationOverride = null): array
     {
         $fieldConfiguration = [
             'type' => 'select',


### PR DESCRIPTION
## Problem

On TYPO3 v14.3 / PHP 8.4+, every console command that loads TCA
(`cache:flush`, `extension:setup`, …) fails with:

> PHP Runtime Deprecation Notice: Implicitly marking parameter `$fieldConfigurationOverride` as nullable is deprecated, the explicit nullable type must be used instead in `vendor/b13/tag/Classes/TcaHelper.php` line 21

PHP 8.4 deprecated implicitly nullable parameters of the form
`Type $x = null`. TYPO3's default `ErrorHandler` promotes that
deprecation into an exception via `exceptionalErrors`, which
aborts the command.

## Fix

Change the signature of `TcaHelper::buildFieldConfiguration()`
from `array $fieldConfigurationOverride = null` to
`?array $fieldConfigurationOverride = null`.

This is a no-op at the behavioural level — the method body
already handles a null override correctly
(`if (!empty($fieldConfigurationOverride))`).

/cc @bmack